### PR TITLE
Feature: load custom.css in user pages

### DIFF
--- a/templates/user_page.html
+++ b/templates/user_page.html
@@ -10,6 +10,7 @@
   {{ end }}
     <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" type="text/css" href="//{{.Config.Host}}/style.css" />
+    <link rel="stylesheet" type="text/css" href="/custom.css" />
   </head>
   <body>
 <main>


### PR DESCRIPTION
Allows users to upload a custom.css file, to be loaded alongside the server-provided style.css, when proxying the page through https.

Slight problem: each time a page with no custom.css file is loaded, the browser still looks for the file, generating an error 404.
The ideal thing would be checking if custom.css is present in the folder before including it in the user_page template.